### PR TITLE
expand and collapse refactor to have better separation of concerns

### DIFF
--- a/addon/collapse-key.js
+++ b/addon/collapse-key.js
@@ -1,0 +1,16 @@
+import expandProperty from './expand-property';
+
+export default function(property) {
+  if (typeof property !== 'string') {
+    return [property];
+  }
+
+  let atEachIndex = property.indexOf('.@each');
+  if (atEachIndex !== -1) {
+    return [property.slice(0, atEachIndex)];
+  } else if (property.slice(-2) === '[]') {
+    return [property.slice(0, -3)];
+  }
+
+  return expandProperty(property);
+}

--- a/addon/collapse-keys.js
+++ b/addon/collapse-keys.js
@@ -1,12 +1,19 @@
-import expandProperty from './expand-property';
+import collapseKey from './collapse-key';
+
+export function collapseKeysWithMap(keys) {
+  let collapsedKeys = [];
+
+  keys.forEach(key => {
+    let array = collapseKey(key);
+
+    collapsedKeys = collapsedKeys.concat(array);
+  });
+
+  return {
+    collapsedKeys
+  }
+}
 
 export default function(keys) {
-  return keys.reduce((newKeys, key) => {
-    if (typeof key === 'string') {
-      newKeys = newKeys.concat(expandProperty(key));
-    } else {
-      newKeys.push(key);
-    }
-    return newKeys;
-  }, []);
+  return collapseKeysWithMap(keys).collapsedKeys;
 }

--- a/addon/expand-property.js
+++ b/addon/expand-property.js
@@ -3,13 +3,6 @@ import Ember from 'ember';
 const { expandProperties } = Ember;
 
 export default function(property) {
-  let atEachIndex = property.indexOf('.@each');
-  if (atEachIndex !== -1) {
-    return [property.slice(0, atEachIndex)];
-  } else if (property.slice(-2) === '[]') {
-    return [property.slice(0, -3)];
-  }
-
   let newPropertyList = [];
   expandProperties(property, expandedProperties => {
     newPropertyList = newPropertyList.concat(expandedProperties);

--- a/tests/unit/collapse-key-test.js
+++ b/tests/unit/collapse-key-test.js
@@ -1,53 +1,46 @@
-import collapseKeys from 'ember-macro-helpers/collapse-keys';
+import collapseKey from 'ember-macro-helpers/collapse-key';
 import { module, test } from 'qunit';
 
-module('Unit | collapse keys');
-
-test('it allows empty arrays', function(assert) {
-  assert.deepEqual(
-    collapseKeys([]),
-    []
-  );
-});
+module('Unit | collapse key');
 
 test('it ignores non-strings', function(assert) {
   assert.deepEqual(
-    collapseKeys([{}]),
+    collapseKey({}),
     [{}]
   );
 });
 
 test('it collapses array.[]', function(assert) {
   assert.deepEqual(
-    collapseKeys(['foo.[]']),
+    collapseKey('foo.[]'),
     ['foo']
   );
 });
 
 test('it collapses array.@each', function(assert) {
   assert.deepEqual(
-    collapseKeys(['foo.@each.bar']),
+    collapseKey('foo.@each.bar'),
     ['foo']
   );
 });
 
 test('it collapses array.@each with brace expansion', function(assert) {
   assert.deepEqual(
-    collapseKeys(['foo.@each.{bar,baz}']),
+    collapseKey('foo.@each.{bar,baz}'),
     ['foo']
   );
 });
 
 test('it ignores string without brace expansion', function(assert) {
   assert.deepEqual(
-    collapseKeys(['foo', 'one']),
-    ['foo', 'one']
+    collapseKey('foo'),
+    ['foo']
   );
 });
 
 test('it collapses brace expansion', function(assert) {
   assert.deepEqual(
-    collapseKeys(['foo.{bar,baz}', 'one.{two,three}']),
-    ['foo.bar', 'foo.baz', 'one.two', 'one.three']
+    collapseKey('foo.{bar,baz}'),
+    ['foo.bar', 'foo.baz']
   );
 });

--- a/tests/unit/expand-property-list-test.js
+++ b/tests/unit/expand-property-list-test.js
@@ -15,26 +15,26 @@ test('it retains any dots', function(assert) {
   assert.deepEqual(result, ['key1.key2']);
 });
 
-test('it strips array []', function(assert) {
+test('it retains array []', function(assert) {
   let result = expandPropertyList(['key1.key2.[]']);
 
-  assert.deepEqual(result, ['key1.key2']);
+  assert.deepEqual(result, ['key1.key2.[]']);
 });
 
-test('it strips array @each', function(assert) {
+test('it retains array @each', function(assert) {
   let result = expandPropertyList(['key1.@each.key2']);
 
-  assert.deepEqual(result, ['key1']);
-});
-
-test('it doesn\'t expand if there\'s an @each', function(assert) {
-  let result = expandPropertyList(['key1.@each.{key2,key3}']);
-
-  assert.deepEqual(result, ['key1']);
+  assert.deepEqual(result, ['key1.@each.key2']);
 });
 
 test('it expands properties', function(assert) {
   let result = expandPropertyList(['key1.{key2,key3}']);
 
   assert.deepEqual(result, ['key1.key2', 'key1.key3']);
+});
+
+test('it expands array properties', function(assert) {
+  let result = expandPropertyList(['key1.@each.{key2,key3}']);
+
+  assert.deepEqual(result, ['key1.@each.key2', 'key1.@each.key3']);
 });

--- a/tests/unit/expand-property-test.js
+++ b/tests/unit/expand-property-test.js
@@ -15,26 +15,26 @@ test('it retains any dots', function(assert) {
   assert.deepEqual(result, ['key1.key2']);
 });
 
-test('it strips array []', function(assert) {
+test('it retains array []', function(assert) {
   let result = expandProperty('key1.key2.[]');
 
-  assert.deepEqual(result, ['key1.key2']);
+  assert.deepEqual(result, ['key1.key2.[]']);
 });
 
-test('it strips array @each', function(assert) {
+test('it retains array @each', function(assert) {
   let result = expandProperty('key1.@each.key2');
 
-  assert.deepEqual(result, ['key1']);
-});
-
-test('it doesn\'t expand if there\'s an @each', function(assert) {
-  let result = expandProperty('key1.@each.{key2,key3}');
-
-  assert.deepEqual(result, ['key1']);
+  assert.deepEqual(result, ['key1.@each.key2']);
 });
 
 test('it expands properties', function(assert) {
   let result = expandProperty('key1.{key2,key3}');
 
   assert.deepEqual(result, ['key1.key2', 'key1.key3']);
+});
+
+test('it expands array properties', function(assert) {
+  let result = expandProperty('key1.@each.{key2,key3}');
+
+  assert.deepEqual(result, ['key1.@each.key2', 'key1.@each.key3']);
 });


### PR DESCRIPTION
breaking change for anyone using these directly, but not for the consumers like `computed`