### PR TITLE
Update name of example addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ember macro helpers for making your own fancy macros!
 Check out the following projects to see this addon in use:
 
 * https://github.com/kellyselden/ember-awesome-macros
-* https://github.com/rwjblue/ember-computed-decorators
+* https://github.com/rwjblue/ember-decorators
 * https://github.com/stefanpenner/ember-moment
 * https://github.com/cibernox/ember-cpm
 


### PR DESCRIPTION
`ember-computed-decorators` was renamed to `ember-decorators`.