### PR TITLE
[BUGFIX] Missing colon in README code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ export default Component.extend({
     }
   }),
 
-  actions {
+  actions: {
     doSomething() {
       this.set('result', 'new value');
     }


### PR DESCRIPTION
Just a missing colon I saw, while checking out the readme file.