### PR TITLE
[BUGFIX] Fixes the isComputed check for beta

### DIFF
--- a/addon/is-computed.js
+++ b/addon/is-computed.js
@@ -1,8 +1,6 @@
 import ComputedProperty from '@ember/object/computed';
 
 export default function(key) {
-  return (
-    key instanceof ComputedProperty ||
-    (typeof key === 'function' && '_getter' in key)
-  );
+  return key instanceof ComputedProperty ||
+    typeof key === 'function' && '_getter' in key;
 }

--- a/addon/is-computed.js
+++ b/addon/is-computed.js
@@ -1,5 +1,8 @@
 import ComputedProperty from '@ember/object/computed';
 
 export default function(key) {
-  return key instanceof ComputedProperty;
+  return (
+    key instanceof ComputedProperty ||
+    (typeof key === 'function' && '_getter' in key)
+  );
 }


### PR DESCRIPTION
In beta, `computed` now returns a decorator function instead of
a ComputedProperty instance (ComputedProperty is now internal only).
This changes the check to be against a function, and to see if it
has the `_getter` property that we still expose for the time being.

This depends on https://github.com/emberjs/ember.js/pull/17855