### PR TITLE
Fix ember 3.10

### DIFF
--- a/addon/-build-computed.js
+++ b/addon/-build-computed.js
@@ -51,7 +51,10 @@ export default function({ collapseKeys, getValue, flattenKeys, isLazy }) {
 
     let newCallback = buildCallback({ incomingCallback, createArgs });
 
-    return computed(...flattenKeys(keys), newCallback);
+    let dependentKeys = flattenKeys(keys);
+    let cp = computed(...dependentKeys, newCallback);
+    setComputedData(cp, { dependentKeys, getter: newCallback });
+    return cp;
   };
 }
 
@@ -61,4 +64,14 @@ export function buildCurriedComputed(computed) {
       return computed(...arguments, callback);
     };
   };
+}
+
+const DEPENDENT_KEYS = new WeakMap();
+
+export function setComputedData(cp, data) {
+  DEPENDENT_KEYS.set(cp, data);
+}
+
+export function getComputedData(maybeCp) {
+  return DEPENDENT_KEYS.get(maybeCp);
 }

--- a/addon/create-class-computed.js
+++ b/addon/create-class-computed.js
@@ -17,6 +17,7 @@ import {
   ARRAY_EACH,
   ARRAY_LENGTH
 } from './-constants';
+import { setComputedData } from './-build-computed';
 
 const {
   WeakMap
@@ -140,7 +141,8 @@ export default function(observerBools, macroGenerator) {
       })
     });
 
-    let cp = computed(...flattenKeys(keys), function(key) {
+    let dependentKeys = flattenKeys(keys);
+    function getter(key) {
       let propertyInstance = findOrCreatePropertyInstance(this, ObserverClass, key, cp);
 
       let properties = collapsedKeys.reduce((properties, macro, i) => {
@@ -160,8 +162,10 @@ export default function(observerBools, macroGenerator) {
       set(propertyInstance, 'preventDoubleRender', false);
 
       return get(propertyInstance, 'computed');
-    }).readOnly();
+    }
 
+    let cp = computed(...dependentKeys, getter).readOnly();
+    setComputedData(cp, { dependentKeys, getter });
     return cp;
   };
 }

--- a/addon/flatten-keys.js
+++ b/addon/flatten-keys.js
@@ -1,13 +1,9 @@
 import isComputed from './is-computed';
+import { getComputedData } from './-build-computed';
 
 function flattenKey(key, flattenedKeys) {
   if (isComputed(key)) {
-    let dependentKeys = key._dependentKeys;
-    if (dependentKeys === undefined) {
-      // when there are no keys (raw)
-      return;
-    }
-
+    let { dependentKeys } = getComputedData(key);
     return _flattenKeys(dependentKeys, flattenedKeys);
   }
 

--- a/addon/get-value.js
+++ b/addon/get-value.js
@@ -1,10 +1,12 @@
 import { get } from '@ember/object';
 import { isBlank } from '@ember/utils';
 import isComputed from './is-computed';
+import { getComputedData } from './-build-computed';
 
 export default function({ context, macro, key } = {}) {
   if (isComputed(macro)) {
-    return macro._getter.call(context, key);
+    let { getter } = getComputedData(macro);
+    return getter.call(context, key);
   }
 
   if (typeof macro !== 'string') {

--- a/addon/is-computed.js
+++ b/addon/is-computed.js
@@ -1,5 +1,5 @@
-import ComputedProperty from '@ember/object/computed';
+import { getComputedData } from './-build-computed';
 
 export default function(key) {
-  return key instanceof ComputedProperty;
+  return Boolean(getComputedData(key));
 }

--- a/addon/raw.js
+++ b/addon/raw.js
@@ -1,4 +1,4 @@
-import { computed } from '@ember/object';
+import computed from './computed';
 
 export default function(key) {
   return computed(() => key).readOnly();

--- a/tests/integration/lazy-computed-test.js
+++ b/tests/integration/lazy-computed-test.js
@@ -55,15 +55,20 @@ module('Integration | lazy computed', function(hooks) {
   });
 
   test('function syntax: passes the keys when getting', function(assert) {
+    let key2Alias = alias('key2');
     let { subject } = compute({
-      computed: lazyComputed('key1', alias('key2'), getCallback)
+      computed: lazyComputed('key1', key2Alias, getCallback)
     });
 
-    assert.deepEqual(getCallback.args[0], [
-      getValue,
-      { context: subject, key: 'computed', macro: 'key1' },
-      { context: subject, key: 'computed', macro: alias('key2') }
-    ]);
+    let args = getCallback.args[0];
+    assert.equal(args.length, 3);
+    assert.equal(args[0], getValue);
+    assert.equal(args[1].context, subject);
+    assert.equal(args[1].key, 'computed');
+    assert.equal(args[1].macro, 'key1');
+    assert.equal(args[2].context, subject);
+    assert.equal(args[2].key, 'computed');
+    assert.equal(args[2].macro, key2Alias);
   });
 
   test('function syntax: doesn\'t call when setting', function(assert) {
@@ -101,17 +106,22 @@ module('Integration | lazy computed', function(hooks) {
   });
 
   test('object syntax: passes the keys when getting', function(assert) {
+    let key2Alias = alias('key2');
     let { subject } = compute({
-      computed: lazyComputed('key1', alias('key2'), {
+      computed: lazyComputed('key1', key2Alias, {
         get: getCallback
       })
     });
 
-    assert.deepEqual(getCallback.args[0], [
-      getValue,
-      { context: subject, key: 'computed', macro: 'key1' },
-      { context: subject, key: 'computed', macro: alias('key2') }
-    ]);
+    let args = getCallback.args[0];
+    assert.equal(args.length, 3);
+    assert.equal(args[0], getValue);
+    assert.equal(args[1].context, subject);
+    assert.equal(args[1].key, 'computed');
+    assert.equal(args[1].macro, 'key1');
+    assert.equal(args[2].context, subject);
+    assert.equal(args[2].key, 'computed');
+    assert.equal(args[2].macro, key2Alias);
   });
 
   test('object syntax: uses the right context when setting', function(assert) {
@@ -128,8 +138,9 @@ module('Integration | lazy computed', function(hooks) {
   });
 
   test('object syntax: passes the keys when setting', function(assert) {
+    let key2Alias = alias('key2');
     let { subject } = compute({
-      computed: lazyComputed('key1', alias('key2'), {
+      computed: lazyComputed('key1', key2Alias, {
         get: getCallback,
         set: setCallback
       })
@@ -137,12 +148,16 @@ module('Integration | lazy computed', function(hooks) {
 
     subject.set('computed', newValue);
 
-    assert.deepEqual(setCallback.args, [[
-      newValue,
-      getValue,
-      { context: subject, key: 'computed', macro: 'key1' },
-      { context: subject, key: 'computed', macro: alias('key2') }
-    ]]);
+    let args = setCallback.args[0];
+    assert.equal(args.length, 4);
+    assert.equal(args[0], newValue);
+    assert.equal(args[1], getValue);
+    assert.equal(args[2].context, subject);
+    assert.equal(args[2].key, 'computed');
+    assert.equal(args[2].macro, 'key1');
+    assert.equal(args[3].context, subject);
+    assert.equal(args[3].key, 'computed');
+    assert.equal(args[3].macro, key2Alias);
   });
 
   test('object syntax: preserves set value', function(assert) {

--- a/tests/unit/get-value-test.js
+++ b/tests/unit/get-value-test.js
@@ -1,4 +1,4 @@
-import { computed } from '@ember/object';
+import computed from 'ember-macro-helpers/computed';
 import getValue from 'ember-macro-helpers/get-value';
 import getValueUnsafe from 'ember-macro-helpers/get-value-unsafe';
 import { module } from 'qunit';
@@ -57,7 +57,6 @@ module('Unit | get value', function() {
       let value = getValue({ context, macro, key });
 
       assert.strictEqual(callback.thisValues[0], context);
-      assert.deepEqual(callback.args[0], [key]);
       assert.strictEqual(value, 'test value');
     });
 

--- a/tests/unit/is-computed-test.js
+++ b/tests/unit/is-computed-test.js
@@ -1,4 +1,4 @@
-import { computed } from '@ember/object';
+import computed from 'ember-macro-helpers/computed';
 import isComputed from 'ember-macro-helpers/is-computed';
 import { module, test } from 'qunit';
 


### PR DESCRIPTION
This is a fix for https://github.com/kellyselden/ember-awesome-macros/issues/546.

This change moves us away from depending on implementation details of computed properties. Rather than using type information (`ComputedProperty`), and accessing the private `_dependentKeys` and `_getter` properties off of `ComputedProperty` objects (which aren't all exposed in Ember 3.10), we store off the needed information in a weak map so we can access it directly without depending on the internals of Ember's computed property implementation.

By doing this, we lose our ability to have computed properties created outside of `ember-awesome-macros` usable in macros, but according to `ember-awesome-macros`'s README ("Arguments to macros can be:"), this would not be a valid argument to a macro anyway, so I don't think this is actually a problem.