### PR TITLE
Fixes engines in package.json to allow Node ^8.3 || >= 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "renovate-config-standard": "^2.0.0"
   },
   "engines": {
-    "node": "8.3 || >= 10.*"
+    "node": "^8.3 || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
PR #273 inadvertently only allowed Node 8.3 within the 8.x series, not later minor releases.