### PR TITLE
Add a setter by default to writable

### DIFF
--- a/addon/writable.js
+++ b/addon/writable.js
@@ -1,9 +1,16 @@
 import computed from './computed';
+import { isPresent } from '@ember/utils';
 
 export default function(getter, setterCallback) {
   let newCallback = {
     get(val) {
+      if (isPresent(this._val)) {
+        return this._val;
+      }
       return val;
+    },
+    set(key, val) {
+      return this._val = val;
     }
   };
 

--- a/addon/writable.js
+++ b/addon/writable.js
@@ -9,7 +9,7 @@ export default function(getter, setterCallback) {
       }
       return val;
     },
-    set(key, val) {
+    set(val) {
       return this._val = val;
     }
   };


### PR DESCRIPTION
This is to avoid deprecation warnings when using ember 3.9 and above https://deprecations.emberjs.com/v3.x/#toc_computed-property-override