### PR TITLE
Set observers explicitly to be sync to support Ember 3.13+

### DIFF
--- a/addon/create-class-computed.js
+++ b/addon/create-class-computed.js
@@ -51,25 +51,29 @@ function findOrCreatePropertyInstance(context, propertyClass, key, cp) {
 
 const BaseClass = EmberObject.extend({
   // eslint-disable-next-line ember/no-observers
-  computedDidChange: observer('computed', function() {
-    let {
-      context,
-      key,
-      preventDoubleRender
-    } = this;
+  computedDidChange: observer({
+    dependentKeys: ['computed'],
+    fn() {
+      let {
+        context,
+        key,
+        preventDoubleRender
+      } = this;
 
-    if (context.isDestroying) {
-      // controllers can get into this state
-      this.destroy();
+      if (context.isDestroying) {
+        // controllers can get into this state
+        this.destroy();
 
-      return;
-    }
+        return;
+      }
 
-    if (preventDoubleRender) {
-      return;
-    }
+      if (preventDoubleRender) {
+        return;
+      }
 
-    context.notifyPropertyChange(key);
+      context.notifyPropertyChange(key);
+    },
+    sync: true
   })
 });
 
@@ -123,7 +127,11 @@ export default function(observerBools, macroGenerator) {
       mappedKeys.push(mappedKey);
       if (shouldObserve) {
         // eslint-disable-next-line ember/no-observers
-        classProperties[`key${i}DidChange`] = observer(mappedKey, rewriteComputed);
+        classProperties[`key${i}DidChange`] = observer({
+          dependentKeys: [mappedKey],
+          fn: rewriteComputed,
+          sync: true
+        });
       }
     });
 


### PR DESCRIPTION
Getting errors when `default-async-observers` is activated.

Following https://guides.emberjs.com/release/configuring-ember/optional-features/#toc_default-async-observers seems to work.